### PR TITLE
Release pantalk-tool

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 CBK.AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@
   <img src="https://pantalk.dev/icon.svg" alt="Pantalk" width="80" height="80" />
 </p>
 
-<h3 align="center">pantalkd - Technical Reference</h3>
+<h3 align="center">Pantalk - Technical Reference</h3>
 
 <p align="center">
-  Daemon, CLI clients, and protocol documentation for the Pantalk tool.
+  Give your AI agent a voice on every chat platform.<br/>
+  Daemon, CLI, and protocol documentation.
 </p>
 
 ---
 
 # Architecture
 
-Pantalk is a Unix-style client-server communication tool for chat services.
+Pantalk lets AI agents send, receive, and stream messages across Slack, Discord, Mattermost, and Telegram through a single interface.
 
 | Component  | Role                                                                                  |
 | ---------- | ------------------------------------------------------------------------------------- |
@@ -23,8 +24,9 @@ All clients connect to `pantalkd` through a **Unix domain socket** using a simpl
 
 ### Design principles
 
+- **Agent-first** - structured output, skill definitions, and notification routing designed for AI agents
 - **One daemon, all platforms** - upstream auth/session complexity lives in `pantalkd`
-- **Unix-native IPC** - JSON over Unix socket, composable with `grep`, `jq`, `xargs`
+- **Composable CLI** - JSON over Unix socket, works with `grep`, `jq`, `xargs`, and any language
 - **Multi-bot** - define multiple bots per service via config
 - **Local-first** - SQLite persistence, no external dependencies
 


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `incubator/pantalk/tool` on branch `next` → `main`.