### PR TITLE
Release pantalk-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ JSON over Unix domain socket. Every request is a single JSON object with an `act
 | Discord    | Gateway           | REST API      |
 | Mattermost | WebSocket         | REST API      |
 | Telegram   | Bot API long-poll | `sendMessage` |
+| WhatsApp   | Web multi-device  | `SendMessage` |
 
 ### Persistence
 
@@ -333,6 +334,7 @@ Each platform requires its own app/bot setup before Pantalk can connect. See the
 | Discord    | [Discord Setup](docs/discord-setup.md)       | Gateway (WebSocket)     |
 | Mattermost | [Mattermost Setup](docs/mattermost-setup.md) | WebSocket + REST API    |
 | Telegram   | [Telegram Setup](docs/telegram-setup.md)     | Bot API (long-poll)     |
+| WhatsApp   | [WhatsApp Setup](docs/whatsapp-setup.md)     | Web multi-device        |
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pantalk/pantalk
 
-go 1.25.0
+go 1.25.7
 
 require (
 	github.com/bwmarrin/discordgo v0.29.0


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `incubator/pantalk/tool` on branch `next` → `main`.